### PR TITLE
NuttX: add example for position DC motor control

### DIFF
--- a/NuttX/DC_MotorPosition/DCMotPos.dgm
+++ b/NuttX/DC_MotorPosition/DCMotPos.dgm
@@ -1,0 +1,464 @@
+<root>
+  <pysimCoder>
+    <pysimCoderVersion>0.9</pysimCoderVersion>
+  </pysimCoder>
+  <Date>
+    <SavingDate>10.09.2021 - 11:58:18</SavingDate>
+  </Date>
+  <Simulation>
+    <Template>nuttx.tmf</Template>
+    <Ts>0.01</Ts>
+    <AddObj></AddObj>
+    <ParScript>/home/michal/Michal/codes/Python/dc.py</ParScript>
+    <Tf>10</Tf>
+  </Simulation>
+  <block>
+    <name>Discrete PID</name>
+    <inp>1</inp>
+    <outp>1</outp>
+    <inset>0</inset>
+    <outset>0</outset>
+    <icon>PID</icon>
+    <params>discretePIDBlk|Proportional gain: 1.6|Integral gain: 0.3|Derivative gain: 0.6|Min value: -3.3|Max value: 3.3</params>
+    <help></help>
+    <width>80</width>
+    <flip>0</flip>
+    <posX>400.0</posX>
+    <posY>20.0</posY>
+  </block>
+  <block>
+    <name>DO0</name>
+    <inp>1</inp>
+    <outp>0</outp>
+    <inset>0</inset>
+    <outset>0</outset>
+    <icon>DO</icon>
+    <params>nuttxDOBlk|Port: '/dev/gpout4'|Threshold: 0.5</params>
+    <help></help>
+    <width>80</width>
+    <flip>0</flip>
+    <posX>-120.0</posX>
+    <posY>470.0</posY>
+  </block>
+  <block>
+    <name>DO</name>
+    <inp>1</inp>
+    <outp>0</outp>
+    <inset>0</inset>
+    <outset>0</outset>
+    <icon>DO</icon>
+    <params>nuttxDOBlk|Port: '/dev/gpout3'|Threshold: 0.5</params>
+    <help></help>
+    <width>80</width>
+    <flip>0</flip>
+    <posX>-120.0</posX>
+    <posY>350.0</posY>
+  </block>
+  <block>
+    <name>Const1</name>
+    <inp>0</inp>
+    <outp>1</outp>
+    <inset>0</inset>
+    <outset>0</outset>
+    <icon>CONST</icon>
+    <params>constBlk|Value: 1</params>
+    <help></help>
+    <width>80</width>
+    <flip>0</flip>
+    <posX>-350.0</posX>
+    <posY>470.0</posY>
+  </block>
+  <block>
+    <name>Const0</name>
+    <inp>0</inp>
+    <outp>1</outp>
+    <inset>0</inset>
+    <outset>0</outset>
+    <icon>CONST</icon>
+    <params>constBlk|Value: 1</params>
+    <help></help>
+    <width>80</width>
+    <flip>0</flip>
+    <posX>-350.0</posX>
+    <posY>350.0</posY>
+  </block>
+  <block>
+    <name>Abs</name>
+    <inp>1</inp>
+    <outp>1</outp>
+    <inset>0</inset>
+    <outset>0</outset>
+    <icon>ABS</icon>
+    <params>absBlk</params>
+    <help></help>
+    <width>80</width>
+    <flip>0</flip>
+    <posX>620.0</posX>
+    <posY>100.0</posY>
+  </block>
+  <block>
+    <name>Const</name>
+    <inp>0</inp>
+    <outp>1</outp>
+    <inset>0</inset>
+    <outset>0</outset>
+    <icon>CONST</icon>
+    <params>constBlk|Value: 0</params>
+    <help></help>
+    <width>80</width>
+    <flip>0</flip>
+    <posX>150.0</posX>
+    <posY>380.0</posY>
+  </block>
+  <block>
+    <name>Output Switch</name>
+    <inp>2</inp>
+    <outp>2</outp>
+    <inset>0</inset>
+    <outset>0</outset>
+    <icon>SWITCH</icon>
+    <params>switchOutBlk|Compare Value: 0.5</params>
+    <help></help>
+    <width>80</width>
+    <flip>0</flip>
+    <posX>800.0</posX>
+    <posY>150.0</posY>
+  </block>
+  <block>
+    <name>PWM</name>
+    <inp>1</inp>
+    <outp>0</outp>
+    <inset>1</inset>
+    <outset>0</outset>
+    <icon>PWM</icon>
+    <params>nuttx_PWMBlk|Port: '/dev/pwm1'|channels: [1]|PWM freq [Hz]: 4000|Umin [V]: 0.0|Umax [V]: 3.3</params>
+    <help></help>
+    <width>80</width>
+    <flip>0</flip>
+    <posX>1030.0</posX>
+    <posY>120.0</posY>
+  </block>
+  <block>
+    <name>PWM0</name>
+    <inp>1</inp>
+    <outp>0</outp>
+    <inset>1</inset>
+    <outset>0</outset>
+    <icon>PWM</icon>
+    <params>nuttx_PWMBlk|Port: '/dev/pwm2'|channels: [1]|PWM freq [Hz]: 4000|Umin [V]: 0.0|Umax [V]: 3.3</params>
+    <help></help>
+    <width>80</width>
+    <flip>0</flip>
+    <posX>1030.0</posX>
+    <posY>230.0</posY>
+  </block>
+  <block>
+    <name>Relation Operator0</name>
+    <inp>2</inp>
+    <outp>1</outp>
+    <inset>0</inset>
+    <outset>0</outset>
+    <icon>REL</icon>
+    <params>relBlk|operator: '&gt;='</params>
+    <help></help>
+    <width>80</width>
+    <flip>0</flip>
+    <posX>520.0</posX>
+    <posY>360.0</posY>
+  </block>
+  <block>
+    <name>TCPsocketTX</name>
+    <inp>2</inp>
+    <outp>0</outp>
+    <inset>1</inset>
+    <outset>0</outset>
+    <icon>TCPSOCKET</icon>
+    <params>TCPsocketTxBlk|IP Addr: '192.168.1.16'|Port: 1024</params>
+    <help>This block implements a TCP sender
+
+Parameters
+IP address of the receiver
+Port
+</help>
+    <width>80</width>
+    <flip>0</flip>
+    <posX>340.0</posX>
+    <posY>170.0</posY>
+  </block>
+  <block>
+    <name>Sub2</name>
+    <inp>2</inp>
+    <outp>1</outp>
+    <inset>0</inset>
+    <outset>0</outset>
+    <icon>PM</icon>
+    <params>sumBlk|Gains: [1,-1]</params>
+    <help></help>
+    <width>80</width>
+    <flip>0</flip>
+    <posX>90.0</posX>
+    <posY>-140.0</posY>
+  </block>
+  <block>
+    <name>Sub</name>
+    <inp>2</inp>
+    <outp>1</outp>
+    <inset>0</inset>
+    <outset>0</outset>
+    <icon>PM</icon>
+    <params>sumBlk|Gains: [1,-1]</params>
+    <help></help>
+    <width>80</width>
+    <flip>0</flip>
+    <posX>260.0</posX>
+    <posY>20.0</posY>
+  </block>
+  <block>
+    <name>ENC</name>
+    <inp>0</inp>
+    <outp>1</outp>
+    <inset>0</inset>
+    <outset>0</outset>
+    <icon>ENC</icon>
+    <params>nuttxENCBlk|Port: '/dev/qe0'|Resolution: 500| reset counter [1 yes]: 1</params>
+    <help>Parameters
+Port: device name
+Resolution: Encoder resolution
+Reset: 1=yes, 0 = no
+
+
+</help>
+    <width>80</width>
+    <flip>0</flip>
+    <posX>-120.0</posX>
+    <posY>180.0</posY>
+  </block>
+  <block>
+    <name>PulseGenerator</name>
+    <inp>0</inp>
+    <outp>1</outp>
+    <inset>0</inset>
+    <outset>0</outset>
+    <icon>SQUARE</icon>
+    <params>squareBlk|Amplitude: 3|Period: 2|Width: 1|Bias: 0|Delay: 0</params>
+    <help>This block implements a Pulse input signal
+
+Parameters:
+Amplitude
+Period (in sec)
+Width of the High signal
+Bias
+Delay
+</help>
+    <width>80</width>
+    <flip>0</flip>
+    <posX>-350.0</posX>
+    <posY>-180.0</posY>
+  </block>
+  <block>
+    <name>PulseGenerator0</name>
+    <inp>0</inp>
+    <outp>1</outp>
+    <inset>0</inset>
+    <outset>0</outset>
+    <icon>SQUARE</icon>
+    <params>squareBlk|Amplitude: 3|Period: 2|Width: 1|Bias: 0|Delay: 1</params>
+    <help>This block implements a Pulse input signal
+
+Parameters:
+Amplitude
+Period (in sec)
+Width of the High signal
+Bias
+Delay
+</help>
+    <width>80</width>
+    <flip>0</flip>
+    <posX>-350.0</posX>
+    <posY>-20.0</posY>
+  </block>
+  <block>
+    <name>Integral</name>
+    <inp>1</inp>
+    <outp>1</outp>
+    <inset>0</inset>
+    <outset>0</outset>
+    <icon>INTG</icon>
+    <params>intgBlk|Initial conditions: 0</params>
+    <help>This block implements a continous integration block
+
+Parameters:
+Initial condition
+</help>
+    <width>80</width>
+    <flip>0</flip>
+    <posX>-130.0</posX>
+    <posY>-180.0</posY>
+  </block>
+  <block>
+    <name>Integral0</name>
+    <inp>1</inp>
+    <outp>1</outp>
+    <inset>0</inset>
+    <outset>0</outset>
+    <icon>INTG</icon>
+    <params>intgBlk|Initial conditions: 0</params>
+    <help>This block implements a continous integration block
+
+Parameters:
+Initial condition
+</help>
+    <width>80</width>
+    <flip>0</flip>
+    <posX>-140.0</posX>
+    <posY>-20.0</posY>
+  </block>
+  <connection>
+    <pos1X>130.0</pos1X>
+    <pos1Y>-140.0</pos1Y>
+    <pos2X>300.0</pos2X>
+    <pos2Y>150.0</pos2Y>
+    <pt>170.0,-140.0</pt>
+    <pt>170.0,0.0</pt>
+    <pt>170.0,0.0</pt>
+    <pt>170.0,150.0</pt>
+  </connection>
+  <connection>
+    <pos1X>130.0</pos1X>
+    <pos1Y>-140.0</pos1Y>
+    <pos2X>220.0</pos2X>
+    <pos2Y>0.0</pos2Y>
+    <pt>170.0,-140.0</pt>
+    <pt>170.0,0.0</pt>
+  </connection>
+  <connection>
+    <pos1X>440.0</pos1X>
+    <pos1Y>20.0</pos1Y>
+    <pos2X>480.0</pos2X>
+    <pos2Y>340.0</pos2Y>
+    <pt>470.0,20.0</pt>
+    <pt>470.0,170.0</pt>
+    <pt>470.0,170.0</pt>
+    <pt>470.0,340.0</pt>
+  </connection>
+  <connection>
+    <pos1X>440.0</pos1X>
+    <pos1Y>20.0</pos1Y>
+    <pos2X>580.0</pos2X>
+    <pos2Y>100.0</pos2Y>
+    <pt>560.0,20.0</pt>
+    <pt>560.0,100.0</pt>
+  </connection>
+  <connection>
+    <pos1X>-310.0</pos1X>
+    <pos1Y>350.0</pos1Y>
+    <pos2X>-160.0</pos2X>
+    <pos2Y>350.0</pos2Y>
+    <pt>-230.0,350.0</pt>
+    <pt>-230.0,350.0</pt>
+  </connection>
+  <connection>
+    <pos1X>-310.0</pos1X>
+    <pos1Y>470.0</pos1Y>
+    <pos2X>-160.0</pos2X>
+    <pos2Y>470.0</pos2Y>
+    <pt>-230.0,470.0</pt>
+    <pt>-230.0,470.0</pt>
+  </connection>
+  <connection>
+    <pos1X>660.0</pos1X>
+    <pos1Y>100.0</pos1Y>
+    <pos2X>760.0</pos2X>
+    <pos2Y>130.0</pos2Y>
+    <pt>730.0,100.0</pt>
+    <pt>730.0,130.0</pt>
+  </connection>
+  <connection>
+    <pos1X>840.0</pos1X>
+    <pos1Y>130.0</pos1Y>
+    <pos2X>990.0</pos2X>
+    <pos2Y>120.0</pos2Y>
+    <pt>940.0,130.0</pt>
+    <pt>940.0,120.0</pt>
+  </connection>
+  <connection>
+    <pos1X>840.0</pos1X>
+    <pos1Y>170.0</pos1Y>
+    <pos2X>990.0</pos2X>
+    <pos2Y>230.0</pos2Y>
+    <pt>940.0,170.0</pt>
+    <pt>940.0,230.0</pt>
+  </connection>
+  <connection>
+    <pos1X>190.0</pos1X>
+    <pos1Y>380.0</pos1Y>
+    <pos2X>480.0</pos2X>
+    <pos2Y>380.0</pos2Y>
+    <pt>300.0,380.0</pt>
+    <pt>300.0,380.0</pt>
+  </connection>
+  <connection>
+    <pos1X>560.0</pos1X>
+    <pos1Y>360.0</pos1Y>
+    <pos2X>760.0</pos2X>
+    <pos2Y>170.0</pos2Y>
+    <pt>630.0,360.0</pt>
+    <pt>630.0,170.0</pt>
+  </connection>
+  <connection>
+    <pos1X>300.0</pos1X>
+    <pos1Y>20.0</pos1Y>
+    <pos2X>360.0</pos2X>
+    <pos2Y>20.0</pos2Y>
+    <pt>330.0,20.0</pt>
+    <pt>330.0,20.0</pt>
+  </connection>
+  <connection>
+    <pos1X>-80.0</pos1X>
+    <pos1Y>180.0</pos1Y>
+    <pos2X>220.0</pos2X>
+    <pos2Y>40.0</pos2Y>
+    <pt>70.0,180.0</pt>
+    <pt>70.0,40.0</pt>
+  </connection>
+  <connection>
+    <pos1X>-80.0</pos1X>
+    <pos1Y>180.0</pos1Y>
+    <pos2X>300.0</pos2X>
+    <pos2Y>190.0</pos2Y>
+    <pt>70.0,180.0</pt>
+    <pt>70.0,190.0</pt>
+  </connection>
+  <connection>
+    <pos1X>-310.0</pos1X>
+    <pos1Y>-20.0</pos1Y>
+    <pos2X>-180.0</pos2X>
+    <pos2Y>-20.0</pos2Y>
+    <pt>-240.0,-20.0</pt>
+    <pt>-240.0,-20.0</pt>
+  </connection>
+  <connection>
+    <pos1X>-310.0</pos1X>
+    <pos1Y>-180.0</pos1Y>
+    <pos2X>-170.0</pos2X>
+    <pos2Y>-180.0</pos2Y>
+    <pt>-250.0,-180.0</pt>
+    <pt>-250.0,-180.0</pt>
+  </connection>
+  <connection>
+    <pos1X>-90.0</pos1X>
+    <pos1Y>-180.0</pos1Y>
+    <pos2X>50.0</pos2X>
+    <pos2Y>-160.0</pos2Y>
+    <pt>-20.0,-180.0</pt>
+    <pt>-20.0,-160.0</pt>
+  </connection>
+  <connection>
+    <pos1X>-100.0</pos1X>
+    <pos1Y>-20.0</pos1Y>
+    <pos2X>50.0</pos2X>
+    <pos2Y>-120.0</pos2Y>
+    <pt>-20.0,-20.0</pt>
+    <pt>-20.0,-120.0</pt>
+  </connection>
+</root>

--- a/NuttX/DC_MotorPosition/README.txt
+++ b/NuttX/DC_MotorPosition/README.txt
@@ -1,0 +1,8 @@
+README
+======
+
+This sections contains an example application of position DC motor control for NuttX RTOS.
+Position is controlled with two PWM outputs and incremental encoder as a feedback. Two GPIO
+outputs are specific for Teensy 4.x board in pikron-bb configuration (for detailed description
+of the configuration please refer to NuttX documentation) and can be removed for other boards
+and configurations.


### PR DESCRIPTION
This commit adds an example file for position DC motor control for NuttX target. Also adds a short readme discribing the
example.